### PR TITLE
Add script to send membership statistics by email

### DIFF
--- a/email-stats
+++ b/email-stats
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+
+from __future__ import (absolute_import, division, print_function)
+
+import argparse
+import datetime
+from email import charset
+from email.header import Header
+from email.mime.text import MIMEText
+import smtplib
+
+import SPI
+
+from jinja2 import Environment, FileSystemLoader
+
+charset.add_charset('utf-8', charset.SHORTEST, charset.QP)
+
+
+def send_stats(db, args):
+    env = Environment(loader=FileSystemLoader('templates/'))
+    template = env.get_template('stats.txt')
+
+    stats = db.get_stats()
+    date = '{:%F %T}'.format(datetime.datetime.today())
+
+    msg = MIMEText(template.render(stats=stats, date=date), 'plain', 'utf-8')
+    msg['Subject'] = Header('SPI membership statistics')
+    msg['From'] = 'SPI Membership Committee <membership@spi-inc.org>'
+    msg['To'] = args.email
+    if not args.dryrun:
+        smtp = smtplib.SMTP('localhost')
+        smtp.sendmail('membership@spi-inc.org',
+            [args.email], msg.as_string())
+        smtp.quit()
+    else:
+        print(msg)
+
+
+parser = argparse.ArgumentParser(description='Email membership statistics')
+parser.add_argument('--email', dest='email',
+                    help="Email address to send message",
+                    action='store', default='board@spi-inc.org')
+parser.add_argument('--dry-run', dest='dryrun',
+                    help="Just show what would happen, don't take any action",
+                    action='store_const', const=True, default=False)
+
+args = parser.parse_args()
+
+db = SPI.MemberDB('postgres', 'spiapp')
+
+send_stats(db, args)
+

--- a/templates/stats.txt
+++ b/templates/stats.txt
@@ -1,0 +1,8 @@
+SPI membership statistics as of {{ date }}
+
+NC Applicants Pending Email Approval: {{ stats['nca']}}
+NC Members: {{ stats['ncm']}}
+Contrib Membership Applications: {{ stats['ca']}}
+Contrib Members: {{ stats['cm']}}
+Application Managers: {{ stats['mgr']}}
+


### PR DESCRIPTION
We record membership statistics at the end of the year for SPI's
annual report.  Let's create a script to email us instead of looking
it up manually.