### PR TITLE
Set default for vote_election:winners for SQLite

### DIFF
--- a/spiapp-sqlite.sql
+++ b/spiapp-sqlite.sql
@@ -52,7 +52,7 @@ CREATE TABLE vote_election (
     period_start timestamp with time zone,
     period_stop timestamp with time zone,
     owner integer NOT NULL,
-    winners integer NOT NULL,
+    winners integer DEFAULT 1 NOT NULL,
     system integer NOT NULL
 );
 


### PR DESCRIPTION
create_vote() fails because it doesn't set winners which is marked as
"NOT NULL".  Set a default value.  This is in line with the way
PostgreSQL is configured on the SPI membership system.